### PR TITLE
Add option to define custom log-likelihood

### DIFF
--- a/hamiltorch/samplers.py
+++ b/hamiltorch/samplers.py
@@ -552,6 +552,10 @@ def define_model_log_prob(model, model_loss, x, y, params_flattened_list, params
         elif model_loss is 'regression':
             # crit = nn.MSELoss(reduction='sum')
             ll = - 0.5 * tau_out * ((output - y) ** 2).mean(0)#sum(0)
+           
+        elif callable(model_loss):
+            # Assume defined custom log-likelihood.
+            ll = - model_loss(output, y).mean(0)
         else:
             raise NotImplementedError()
         if predict:


### PR DESCRIPTION
Allows you to pass model_loss as a function rather than a string, so you can define custom log-likelihoods. Assumes that model_loss takes prediction and target as inputs, and returns the unreduced log-likelihood for each row as output.